### PR TITLE
Fix invalid include paths.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"extra": {
 		"phpstan": {
 			"includes": [
-				"rules.neon"
+				"extension.neon"
 			]
 		}
 	},


### PR DESCRIPTION
Include extension.neon instead of rules.neon which does not exists